### PR TITLE
Add @package to the docs

### DIFF
--- a/can-event-dom-enter.js
+++ b/can-event-dom-enter.js
@@ -32,6 +32,7 @@ function disassociateHandler (target, eventType, handler) {
 /**
  * @module {events} can-event-dom-enter
  * @parent can-infrastructure
+ * @package ./package.json
  *
  * Watch for when enter keys are pressed on a DomEventTarget.
  *


### PR DESCRIPTION
This fixes an issue with the GitHub star and npm download buttons not appearing in the rendered canjs.com docs.