### PR TITLE
Fix the tests to run in the main CanJS test suite

### DIFF
--- a/can-event-dom-enter-test.js
+++ b/can-event-dom-enter-test.js
@@ -4,7 +4,7 @@ var unit = require('steal-qunit');
 var domEvents = require('can-dom-events');
 var definition = require('./can-event-dom-enter');
 var compat = require('./compat');
-var enterEventType = 'enter';
+var enterEventType = 'test-enter';
 
 function makeEnterEvent() {
 	try {


### PR DESCRIPTION
In the main CanJS build, can-stache-bindings is included and registers the enter event, which previously conflicted with these tests. This is fixed by not registering the same event name in these tests.